### PR TITLE
Allow ChoiceOptions to have a falsy value

### DIFF
--- a/src/components/Question.vue
+++ b/src/components/Question.vue
@@ -228,7 +228,9 @@
           return false
         }
       
-        if (!q || !this.dataValue) {
+        // if there is no question referenced, or dataValue is still set to one of its defaults (null, from above; '' from the default ChoiceOption)
+        // this allows a ChoiceOption value of false, but will not allow you to use null or '' as a value.
+        if (!q || this.dataValue === null || this.dataValue === '') {
           return false
         }
 
@@ -241,7 +243,7 @@
       showInvalid() {
         const q = this.$refs.questionComponent
 
-        if (!q || !this.dataValue) {
+        if (!q || this.dataValue === null || this.dataValue === '') { // see comment above regarding null options
           return false
         }
 

--- a/src/models/QuestionModel.js
+++ b/src/models/QuestionModel.js
@@ -46,7 +46,9 @@ export class ChoiceOption {
   }
 
   choiceValue() {
-    return this.value || this.label
+    // returns the value if it's anything other than the default (an empty string).
+    // returns label if the value has not been set.
+    return this.value !== '' ? this.value : this.label
   }
 
   toggle() {


### PR DESCRIPTION
Issue #134 was closed a bit prematurely it seems-- having `0` or `false` as a value in a `ChoiceOption` would evaluate as false and thus return `ChoiceOption.label` instead. This fix allows you to pass falsy values as a `ChoiceOption.value` by evaluating the value more stringently than just as falsy/truthy.

Note, you can still not pass `null` or `''` as values to `ChoiceOption`. The `ChoiceOption` class uses `''` as its default value for empty, but `Question.vue`'s `dataValue` uses `null` as the default for empty. Though this is inconsistent and might be better using the same value for both, I didn't change it because I wasn't sure if there was a reason for it or not. If `ChoiceOption` used `null` as its default empty value, then `''` could potentially also be passed as a value. This likely will be useful to someone in the future.