### PR TITLE
Allow Objects as answers to questions

### DIFF
--- a/src/components/Question.vue
+++ b/src/components/Question.vue
@@ -128,7 +128,7 @@
     props: {
       question: QuestionModel,
       language: LanguageModel,
-      value: [String, Array, Boolean, Number],
+      value: [String, Array, Boolean, Number, Object],
       active: {
         type: Boolean,
         default: false

--- a/src/components/QuestionTypes/BaseType.vue
+++ b/src/components/QuestionTypes/BaseType.vue
@@ -17,7 +17,7 @@
       language: LanguageModel,
       question: QuestionModel,
       active: Boolean,
-      value: [String, Array, Boolean, Number]
+      value: [String, Array, Boolean, Number, Object]
     },
     mixins: [
       IsMobile,

--- a/src/models/QuestionModel.js
+++ b/src/models/QuestionModel.js
@@ -123,7 +123,6 @@ export default class QuestionModel {
   }
 
   setAnswer(answer) {
-    console.log(answer)
     if (this.type === QuestionType.Number && answer !== '' && !isNaN(+answer)) {
       answer = +answer
     }


### PR DESCRIPTION
Consider the following:
```javascript
healthcareOptions = [
    new ChoiceOption({
        label: 'family: $7,100 annually (deducted from pay)',
        value: {amount: 7100, type: 'deducted'}
    }),
    new ChoiceOption({
        label: 'family: $7,100 annually (contributed out of pocket)',
        value: {amount: 7100, type: 'contributed'}
    }),
    new ChoiceOption({
        label: 'individual: $3,550 annually (deducted from pay)',
        value: {amount: 3500, type: 'deducted'}
    }),
    new ChoiceOption({
        label: 'individual: $3,550 annually (contributed out of pocket)',
        value: {amount: 3500, type: 'contributed'}
    }),
    new ChoiceOption({
        label: 'none',
        value: {amount: 0, type: null}
    })
]
```
Here the choices are more than just numbers, they also need some metadata to go along with the number. The above implementation already works because Vue isn't strict in its validation of props, but it kicks up a prop validation warning with each question answered. This change formally supports setting an `Object` as a `ChoiceOption.value`.

The only downside I could see to this is that if you pass only a `Object` `value` and not a `label` to a `ChoiceOption`, the `Object` would be printed as a string. This is an atypical case and is easily solved by providing a `label`.

This PR also removes a stray `console.log` that got left behind in a previous PR.