### PR TITLE
[WIP] Added some touches to existing features

### DIFF
--- a/src/components/Question.vue
+++ b/src/components/Question.vue
@@ -71,7 +71,10 @@
           v-bind:aria-label="language.ariaOk"
         >
             <span v-if="question.type === QuestionType.SectionBreak">{{ language.continue }}</span>
-            <span v-else>{{ language.ok }}</span>
+            <span v-else>
+              <span v-if="this.dataValue !== ''">{{ language.ok }}</span>
+              <span v-else>{{ language.skip }}</span>
+            </span>
         </button>
         <a 
           class="f-enter-desc"

--- a/src/components/Question.vue
+++ b/src/components/Question.vue
@@ -245,6 +245,10 @@
           return this.active
         }
 
+        if (!this.question.required) {
+          return true
+        }
+
         if (this.question.allowOther && this.question.other) {
           return true
         }

--- a/src/components/QuestionTypes/SectionBreakType.vue
+++ b/src/components/QuestionTypes/SectionBreakType.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="f-content" v-if="question.content">
-    <span class="f-section-text">{{ question.content }}</span>
+    <span class="f-section-text" v-html="question.content">{{ question.content }}</span>
   </div>
 </template>
 

--- a/src/models/LanguageModel.js
+++ b/src/models/LanguageModel.js
@@ -12,6 +12,7 @@ export default class LanguageModel {
     this.shiftKey = 'Shift'
     this.ok = 'OK'
     this.continue = 'Continue'
+    this.skip = 'Skip'
     this.pressEnter = 'Press :enterKey'
     this.multipleChoiceHelpText = 'Choose as many as you like'
     this.multipleChoiceHelpTextSingle = 'Choose only one answer'


### PR DESCRIPTION
### 1. Show the OK button if question isn't required. 0e70540
I have users complaining that they had a hard time finding where to skip a question when it isn't required. Turns out, the f-next svg is not intuitive enough to let users know they can skip.
<table>
<tr>
<th><b>Before</b></th>
<th><b>After</b></th>
</tr>
<tr>
<th><img src="https://user-images.githubusercontent.com/35146998/101261811-d12c2f80-3774-11eb-9a62-a732889fe48f.png"></th>
<th><img src="https://user-images.githubusercontent.com/35146998/101261955-dfc71680-3775-11eb-9844-89812d5afec5.png"></th>
</tr>
</table><br>

### 2. Change Ok to Skip when question isn't required && question has no value. 90cb147
Following the previous statement, I think it would be better when the button that directly shows up indicates `Skip` instead of `Ok` when question has no input, but will change to `Ok` when user starts typing.
<table>
<tr>
<th><b>Has no value</b></th>
<th><b>Has value</b></th>
</tr>
<tr>
<th><img src="https://user-images.githubusercontent.com/35146998/101261910-7b0bbc00-3775-11eb-9d64-7d4301409b31.png"></th>
<th><img src="https://user-images.githubusercontent.com/35146998/101261988-169d2c80-3776-11eb-9daf-92c57c700e5b.png"></th>
</tr>
</table><br>

### 3. Allow for styling in section break content. b2143d7
This is also from my users' feedbacks.  Section break content only displays a long string and no stylings or layouts are supported. After this little addition, we can customize the content to better describe the questionnaire or the questions after the section break. Previously developed pages will still look the same as before if no html tags are present.
<table>
<tr>
<th><b>Before</b></th>
<th><b>After</b></th>
</tr>
<tr>
<th><img src="https://user-images.githubusercontent.com/35146998/101262229-071ee300-3778-11eb-9c02-bc29cccba6bb.png"></th>
<th><img src="https://user-images.githubusercontent.com/35146998/101262236-11d97800-3778-11eb-93b9-08e76d956860.png"></th>
</tr>
</table>