### PR TITLE
Fix validation check on mask length bug

### DIFF
--- a/src/components/QuestionTypes/TextType.vue
+++ b/src/components/QuestionTypes/TextType.vue
@@ -71,7 +71,7 @@
             return this.question.mask.some(mask => mask.length === this.dataValue.length)
           }
 
-          return this.dataValue.length !== this.question.mask.length
+          return this.dataValue.length === this.question.mask.length
         }
 
         return !this.question.required || this.hasValue


### PR DESCRIPTION
A bug on the validation check on the TextType question was introduced with https://github.com/ditdot-dev/vue-flow-form/commit/3fedfcd02722b98ef43456db990592f69375fb69 

It returns false if the dataValue.length equals the mask.length and causes validation to fail. It should return true if they are equal. This update fixes that bug.