### PR TITLE
Fix "$slots.default is not a function"

### DIFF
--- a/src/components/FlowForm.vue
+++ b/src/components/FlowForm.vue
@@ -307,7 +307,7 @@
               descriptionLink: LinkOption
             }
 
-            const defaultSlot = this.$slots.default()
+            const defaultSlot = this.$slots.default && this.$slots.default()
             let children = null
 
             if (defaultSlot && defaultSlot.length) {


### PR DESCRIPTION
Hi,
I'm using your package with Vue 3 and when I invoke flow-form component, I have this error.

Apparently if there is no slots, $slots.default is undefined