### PR TITLE
fix: only show completed screen after completed trigger has emitted

### DIFF
--- a/src/components/FlowForm.vue
+++ b/src/components/FlowForm.vue
@@ -22,7 +22,7 @@
         <slot></slot>
 
         <!-- Complete/Submit screen slots -->   
-        <div v-if="isOnLastStep" class="vff-animate f-fade-in-up field-submittype">
+        <div v-if="completed" class="vff-animate f-fade-in-up field-submittype">
           <slot name="complete">
             <!-- Default content for the "complete" slot -->
             <div class="f-section-wrap">


### PR DESCRIPTION
Prevents the completed screen from being shown before navigating away to a custom final screen.