### PR TITLE
Allow de-selection (skipping) of MultipleChoiceType when multiple = false and required = false

### DIFF
--- a/src/components/QuestionTypes/MultipleChoiceType.vue
+++ b/src/components/QuestionTypes/MultipleChoiceType.vue
@@ -90,7 +90,7 @@
         }
       }
     },
-    
+
     methods: {
       addKeyListener() {
         this.removeKeyListener()
@@ -144,16 +144,14 @@
             this.question.other = this.dataValue = null
             this.setAnswer(this.dataValue)
           }
-
           for (let i = 0; i < this.question.options.length; i++) {
             let o = this.question.options[i]
 
-            if (o.selected) {
+            if (o.selected && o !== option) {
               this._toggleAnswer(o)
             }
           }
         }
-
         this._toggleAnswer(option)
       },
 
@@ -174,7 +172,7 @@
           this.dataValue = option.selected ? optionValue : null
         }
 
-      
+
         if (this.isValid() && this.question.nextStepOnAnswer && !this.question.multiple && !this.disabled) {
           this.$emit('next')
         }
@@ -225,7 +223,7 @@
           this.setAnswer(this.dataValue)
         }
       },
-      
+
       stopEditOther() {
         this.editingOther = false
       }

--- a/vue.config.js
+++ b/vue.config.js
@@ -10,13 +10,9 @@ module.exports = {
       // Replace with your .js entry file path.
       // To see the quiz example, use 'examples/quiz/main.js'
       // To see the support page example, use 'examples/support-page/main.js'
-      entry: entry || 'examples/quiz/main.js', //'examples/questionnaire/main.js',
+      entry: entry || 'examples/questionnaire/main.js',
       template: 'public/index.html',
       filename: 'index.html'
     }
-  },
-  transpileDependencies: true,
-  configureWebpack: {
-    devtool: 'source-map',
   }
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -7,12 +7,16 @@ module.exports = {
   publicPath: '',
   pages: {
     index: {
-      // Replace with your .js entry file path. 
+      // Replace with your .js entry file path.
       // To see the quiz example, use 'examples/quiz/main.js'
       // To see the support page example, use 'examples/support-page/main.js'
-      entry: entry || 'examples/questionnaire/main.js',
+      entry: entry || 'examples/quiz/main.js', //'examples/questionnaire/main.js',
       template: 'public/index.html',
       filename: 'index.html'
     }
+  },
+  transpileDependencies: true,
+  configureWebpack: {
+    devtool: 'source-map',
   }
 }


### PR DESCRIPTION
When a question is set to `required: false` and also `multiple: false` it should be possible to de-select an answer.
This change makes it possible to skip the question after a mistaken selection, if desired.

This refers to issue #290 

